### PR TITLE
Add configurable sideload

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,19 @@ If you have logged in users and you always want to associate newly created recor
 
 The `emberizeJSON` method in *actionUtil.js* can transform your populated *embedded* records into sideloaded records, but you have to decide when is the right time to do this depending on your API needs.
 
-You can use the `performSideload` switch at the beginning of each blueprint to set the behavior, but a better way would be to implement some kind of hook that determines whether to sideload or not based on the request.
+To enable this behavior, add the following lines to the `config/blueprints.js` file:
+
+```
+// config/blueprints.js
+module.exports.blueprints = {
+  // existing configuration
+  // ...
+
+  ember: {
+    sideload: true
+  }
+}
+```
 
 ### Accessing the REST interface without Ember Data
 

--- a/blueprints/find.js
+++ b/blueprints/find.js
@@ -5,10 +5,15 @@ var util = require( 'util' ),
   actionUtil = require( './_util/actionUtil' );
 
 /**
- * Switch to enable sideloading records - this is a temporary workaround until we find a more general solution
+ * Enable sideloading. Edit config/blueprints.js and add:
+ *   ember: {
+ *     sideload: true
+ *   }
+ * Defaults to false.
+ *
  * @type {Boolean}
  */
-var performSideload = false;
+var performSideload = (sails.config.blueprints.ember && sails.config.blueprints.ember.sideload);
 
 /**
  * Find Records

--- a/blueprints/findone.js
+++ b/blueprints/findone.js
@@ -5,10 +5,15 @@ var util = require( 'util' ),
   actionUtil = require( './_util/actionUtil' );
 
 /**
- * Switch to enable sideloading records - this is a temporary workaround until we find a more general solution
+ * Enable sideloading. Edit config/blueprints.js and add:
+ *   ember: {
+ *     sideload: true
+ *   }
+ * Defaults to false.
+ *
  * @type {Boolean}
  */
-var performSideload = false;
+var performSideload = (sails.config.blueprints.ember && sails.config.blueprints.ember.sideload);
 
 /**
  * Find One Record

--- a/blueprints/update.js
+++ b/blueprints/update.js
@@ -7,10 +7,15 @@ var util = require( 'util' );
 var _ = require( 'lodash' );
 
 /**
- * Switch to enable sideloading records - this is a temporary workaround until we find a more general solution
+ * Enable sideloading. Edit config/blueprints.js and add:
+ *   ember: {
+ *     sideload: true
+ *   }
+ * Defaults to false.
+ *
  * @type {Boolean}
  */
-var performSideload = false;
+var performSideload = (sails.config.blueprints.ember && sails.config.blueprints.ember.sideload);
 
 /**
  * Update One Record


### PR DESCRIPTION
Instead of having to manually change the `performSideload` variable on all files, you'll only have to add a new config in `blueprints.js` file.
Example:

```
// config/blueprints.js
module.exports.blueprints = {
    // existing configuration
    // ...

    ember: {
        sideload: true
    }
}
```
